### PR TITLE
Refactor translations and add Hario Switch usage information in the app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -174,7 +174,7 @@ function calculateSteps(beansAmount: number, flavor: string) {
     descriptionKey: "strengthPour2",
     status: 'upcoming'
   });
- // Final step (finish) is fixed at 210 seconds
+  // Final step (finish) is fixed at 210 seconds
   steps.push({
     time: 210,
     pourAmount: 0,
@@ -243,7 +243,7 @@ function App() {
       setRoastLevel(paramRoast);
     }
   }, [searchParams]);
-  
+
   // Recalculate steps whenever coffee parameters change
   useEffect(() => {
     const newSteps = calculateSteps(beansAmount, flavor);
@@ -332,6 +332,18 @@ function App() {
           {t.title}
         </Typography>
 
+        <Typography variant="body1" align="center" gutterBottom>
+          {t.usesHarioSwitch(
+            <a
+              href={t.harioSwitchLink}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ color: theme.palette.primary.main }}
+            >
+              Hario Switch
+            </a>
+          )}
+        </Typography>
         <Settings
           t={t}
           beansAmount={beansAmount}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -58,6 +58,9 @@ const Footer: React.FC<FooterProps> = ({ t }) => {
           @takatama_jp
         </Link>
       </Box>
+      <Typography variant="caption" display="block" align="center" sx={{ mt: 2 }}>
+        {t.amazonAssociate}
+      </Typography>
     </Box>
   );
 };

--- a/src/translations/index.tsx
+++ b/src/translations/index.tsx
@@ -33,6 +33,9 @@ export const translations: Record<'en' | 'ja', TranslationType> = {
     footerMethodBy: "The new hybrid method was developed by Tetsu Kasuya",
     footerMethodVideo: "Watch the Method Video",
     footerCreatedBy: "Drip Recipes was developed by Hirokazu Takatama",
+    usesHarioSwitch: (link: JSX.Element) => (<>This recipe uses {link}.</>),
+    harioSwitchLink: "https://amzn.to/40TjUkH",
+    amazonAssociate: "As an Amazon Associate, Drip Recipes earns from qualifying purchases.",
   },
   ja: {
     title: "新しいハイブリッドメソッド",
@@ -66,5 +69,8 @@ export const translations: Record<'en' | 'ja', TranslationType> = {
     footerMethodBy: "新しいハイブリッドメソッドは粕谷哲氏が考案しました",
     footerMethodVideo: "メソッドの解説動画",
     footerCreatedBy: "Drip Recipes was developed by Hirokazu Takatama",
+    usesHarioSwitch: (link: JSX.Element) => (<>このレシピは {link} を使います。</>),
+    harioSwitchLink: "https://amzn.to/3QjLse1",
+    amazonAssociate: "Amazonのアソシエイトとして、Drip Recipesは適格販売により収入を得ています。",
   }
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,9 @@ export interface StaticTranslations {
   footerMethodBy: string;
   footerMethodVideo: string;
   footerCreatedBy: string;
+  usesHarioSwitch: (link: JSX.Element) => JSX.Element;
+  harioSwitchLink: string;
+  amazonAssociate: string;
 }
 
 export interface DynamicTranslations {


### PR DESCRIPTION
Refactor translation strings to include Hario Switch usage details and add an Amazon Associate disclaimer in the footer. Update the app to display this information appropriately.